### PR TITLE
As Gatsby supports IE9 out of the box, I added the Mozilla's polyfill for window.CustomEvent into the mix.

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -1,7 +1,7 @@
 {
-  "dependencies": {
-    "gatsby": "^1.9.277",
-    "gatsby-plugin-page-transitions": "^1.0.6",
-    "react-transition-group": "^2.4.0"
-  }
+    "dependencies": {
+        "gatsby": "^1.9.277",
+        "gatsby-plugin-page-transitions": "^1.0.7",
+        "react-transition-group": "^2.4.0"
+    }
 }

--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -4,9 +4,11 @@ import {
   pageTransitionTime,
   pageTransitionExists,
   componentTransitionTime,
+  CustomEventPolyfill
 } from './index.js';
 
 exports.onClientEntry = (_, { transitionTime }) => {
+  CustomEventPolyfill();
   global.window[pageTransitionTime] = transitionTime || 250;
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -88,3 +88,22 @@ PageTransition.propTypes = {
 };
 
 export default PageTransition;
+
+/**
+ * Some browsers do not have access to window.CustomEvent
+ */
+export const  CustomEventPolyfill = () => {
+    if ( typeof window.CustomEvent === 'function' ) return false;
+
+    function CustomEvent ( event, params ) {
+      params = params || { bubbles: false, cancelable: false, detail: undefined };
+      var evt = document.createEvent( 'CustomEvent' );
+      evt.initCustomEvent( event, params.bubbles, params.cancelable, params.detail );
+      return evt;
+    }
+
+    CustomEvent.prototype = window.Event.prototype;
+
+    window.CustomEvent = CustomEvent;
+    global.window.CustomEvent = CustomEvent;
+};


### PR DESCRIPTION
As Gatsby supports IE9 out of the box, I added the Mozilla's polyfill for window.CustomEvent into the mix.
Updated example/package.json with newer version number.