### PR TITLE
Swap replaceHistory with onRouteUpdate

### DIFF
--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -24,4 +24,4 @@ const getUserConfirmation = (pathname, callback) => {
 
 const history = createHistory({ getUserConfirmation });
 history.block(location => location.pathname);
-exports.replaceHistory = () => history;
+exports.onRouteUpdate = () => history;


### PR DESCRIPTION
For Gatsby v2 Support.

https://www.gatsbyjs.org/docs/migrating-from-v1-to-v2/#browser-api-replacehistory-was-removed

Resolves the API error when using Gatsby v2.